### PR TITLE
Removed function for validation on SQL-side; Added function to return password

### DIFF
--- a/postgreSQL-migrations/V2.7.6__Issue_No_5.sql
+++ b/postgreSQL-migrations/V2.7.6__Issue_No_5.sql
@@ -1,0 +1,23 @@
+DROP FUNCTION IF EXISTS "user".validate_user_credentials;
+
+CREATE OR REPLACE FUNCTION "user"."find_user_hashed_password"(
+   p_username varchar(64)
+) RETURNS text AS $$
+DECLARE
+   v_hashed_password text;
+BEGIN
+   SELECT "hashed_password" INTO v_hashed_password
+   FROM "user"."accounts"
+   WHERE "username" = p_username
+   LIMIT 1;
+
+   IF v_hashed_password IS NULL THEN
+      RAISE EXCEPTION 'Username not found: %', p_username;
+   END IF;
+
+   RETURN v_hashed_password;
+EXCEPTION
+   WHEN OTHERS THEN
+      RETURN 'NOT FOUND';
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
resolve #5 

Removed `user.validate_user_credentials` function.

Added a new function, `user.find_user_hashed_password`, where it takes in a username,  and it will return the related `hashed_password` field belonging to the username.<br>If there is no matching row, a `NOT FOUND` message will be sent.
