### PR TITLE
Bind session token to browser

### DIFF
--- a/postgreSQL-migrations/V2.7.7__Issue_Num_3.sql
+++ b/postgreSQL-migrations/V2.7.7__Issue_Num_3.sql
@@ -49,3 +49,10 @@ BEGIN
   WHERE u.id = user_id;
 END;
 $$ LANGUAGE plpgsql;
+
+-- Set to cascade delete the session token when the account is deleted.
+ALTER TABLE "user"."account_sessions"
+ADD CONSTRAINT fk_account_sessions_account_id
+FOREIGN KEY (account_id)
+REFERENCES "user"."accounts"(id)
+ON DELETE CASCADE;

--- a/postgreSQL-migrations/V2.7.7__Issue_Num_3.sql
+++ b/postgreSQL-migrations/V2.7.7__Issue_Num_3.sql
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION "user".check_session_token(session_token VARCHAR, browser_info TEXT)
+RETURNS TABLE (
+  message VARCHAR,
+  account_id INT,
+  username VARCHAR(64),
+  email VARCHAR,
+  created_at TIMESTAMP
+) AS $$
+DECLARE
+  user_id INT;
+BEGIN
+  -- Find the user_id associated with the session_token
+  SELECT account_id INTO user_id
+  FROM "user"."account_sessions"
+  WHERE session_token = session_token;
+  
+  -- No matching session token...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'INVALID'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  -- Check for expiration
+  DELETE FROM "user"."account_sessions"
+  WHERE session_token = session_token
+  AND expiry_time < NOW();
+  
+  -- Token expired...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'EXPIRED'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  -- Check browser_info
+  SELECT COUNT(*) INTO user_id
+  FROM "user"."account_sessions"
+  WHERE session_token = session_token
+  AND lower(browser_info) = lower(browser_info);
+  
+  -- Browser info doesn't match...
+  IF user_id = 0 THEN
+    -- Session token is likely compromised, so delete it.
+    DELETE FROM "user"."account_sessions"
+    WHERE session_token = session_token;
+
+    RETURN QUERY SELECT 'BROWSER'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  RETURN QUERY SELECT 'OK'::VARCHAR, u.id, u.username, u.email, u.created_at
+  FROM "user"."accounts" u
+  WHERE u.id = user_id;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Title;

Session token is now bind to browser type, the checking happens as SQL side, non-case sensitive.<br>If another user tries to access the token with a different browser type, it drops the current row with the session token, and returns `BROWSER` message.

> It drops the current row with session token as we assume the session token is compromised...

Additionally, make it return the account's id as well.