### PR TITLE
Bugfix on `check_session_token`; Namespace ambiguity and expired check

### DIFF
--- a/postgreSQL-migrations/V2.8.4__BugFix-Ambigious-Name.sql
+++ b/postgreSQL-migrations/V2.8.4__BugFix-Ambigious-Name.sql
@@ -1,0 +1,52 @@
+CREATE OR REPLACE FUNCTION "user".check_session_token(session_token VARCHAR, browser_info TEXT)
+RETURNS TABLE (
+  message VARCHAR,
+  account_id INT,
+  username VARCHAR(64),
+  email VARCHAR,
+  created_at TIMESTAMP
+) AS $$
+DECLARE
+  user_id INT;
+BEGIN
+  -- Find the user_id associated with the session_token
+  SELECT acc_ses.account_id INTO user_id
+  FROM "user"."account_sessions" acc_ses
+  WHERE acc_ses.session_token = session_token;
+  
+  -- No matching session token...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'INVALID'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  -- Check for expiration
+  DELETE FROM "user"."account_sessions" acc_ses
+  WHERE acc_ses.session_token = session_token
+  AND acc_ses.expiry_time < NOW();
+  
+  -- Token expired...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'EXPIRED'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  -- Check browser_info
+  SELECT COUNT(*) INTO user_id
+  FROM "user"."account_sessions" acc_ses
+  WHERE acc_ses.session_token = session_token
+  AND lower(acc_ses.browser_info) = lower(browser_info);
+  
+  -- Browser info doesn't match...
+  IF user_id = 0 THEN
+    -- Session token is likely compromised, so delete it.
+    DELETE FROM "user"."account_sessions" acc_ses
+    WHERE acc_ses.session_token = session_token;
+
+    RETURN QUERY SELECT 'BROWSER'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  RETURN QUERY SELECT 'OK'::VARCHAR, u.id, u.username, u.email, u.created_at
+  FROM "user"."accounts" u
+  WHERE u.id = user_id;
+END;
+$$ LANGUAGE plpgsql;
+

--- a/postgreSQL-migrations/V2.8.5__BugFix-Parameter-Ambigiouity.sql
+++ b/postgreSQL-migrations/V2.8.5__BugFix-Parameter-Ambigiouity.sql
@@ -1,0 +1,54 @@
+DROP FUNCTION "user".check_session_token(character varying,text);
+
+CREATE OR REPLACE FUNCTION "user".check_session_token(p_session_token VARCHAR, p_browser_info TEXT)
+RETURNS TABLE (
+  message VARCHAR,
+  account_id INT,
+  username VARCHAR(64),
+  email VARCHAR,
+  created_at TIMESTAMP
+) AS $$
+DECLARE
+  user_id INT;
+BEGIN
+  -- Find the user_id associated with the session_token
+  SELECT account_id INTO user_id
+  FROM "user"."account_sessions"
+  WHERE session_token = p_session_token;
+  
+  -- No matching session token...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'INVALID'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  -- Check for expiration
+  DELETE FROM "user"."account_sessions"
+  WHERE session_token = p_session_token
+  AND expiry_time < NOW();
+  
+  -- Token expired...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'EXPIRED'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  -- Check browser_info
+  SELECT COUNT(*) INTO user_id
+  FROM "user"."account_sessions"
+  WHERE session_token = p_session_token
+  AND lower(browser_info) = lower(p_browser_info);
+  
+  -- Browser info doesn't match...
+  IF user_id = 0 THEN
+    -- Session token is likely compromised, so delete it.
+    DELETE FROM "user"."account_sessions"
+    WHERE session_token = p_session_token;
+
+    RETURN QUERY SELECT 'BROWSER'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  RETURN QUERY SELECT 'OK'::VARCHAR, u.id, u.username, u.email, u.created_at
+  FROM "user"."accounts" u
+  WHERE u.id = user_id;
+END;
+$$ LANGUAGE plpgsql;
+

--- a/postgreSQL-migrations/V2.8.6__BugFix-Ambigiouity-Column.sql
+++ b/postgreSQL-migrations/V2.8.6__BugFix-Ambigiouity-Column.sql
@@ -1,0 +1,52 @@
+CREATE OR REPLACE FUNCTION "user".check_session_token(p_session_token VARCHAR, p_browser_info TEXT)
+RETURNS TABLE (
+  message VARCHAR,
+  account_id INT,
+  username VARCHAR(64),
+  email VARCHAR,
+  created_at TIMESTAMP
+) AS $$
+DECLARE
+  user_id INT;
+BEGIN
+  -- Find the user_id associated with the session_token
+  SELECT acc_ses.account_id INTO user_id
+  FROM "user"."account_sessions" AS acc_ses
+  WHERE acc_ses.session_token = p_session_token;
+  
+  -- No matching session token...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'INVALID'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  -- Check for expiration
+  DELETE FROM "user"."account_sessions"
+  WHERE session_token = p_session_token
+  AND expiry_time < NOW();
+  
+  -- Token expired...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'EXPIRED'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  -- Check browser_info
+  SELECT COUNT(*) INTO user_id
+  FROM "user"."account_sessions" AS acc_ses
+  WHERE acc_ses.session_token = p_session_token
+  AND lower(acc_ses.browser_info) = lower(p_browser_info);
+  
+  -- Browser info doesn't match...
+  IF user_id = 0 THEN
+    -- Session token is likely compromised, so delete it.
+    DELETE FROM "user"."account_sessions"
+    WHERE session_token = p_session_token;
+
+    RETURN QUERY SELECT 'BROWSER'::VARCHAR, NULL, NULL, NULL, NULL;
+  END IF;
+
+  RETURN QUERY SELECT 'OK'::VARCHAR, u.id, u.username, u.email, u.created_at
+  FROM "user"."accounts" AS u
+  WHERE u.id = user_id;
+END;
+$$ LANGUAGE plpgsql;
+

--- a/postgreSQL-migrations/V2.8.7__BugFix-Casting-Null-To-Type.sql
+++ b/postgreSQL-migrations/V2.8.7__BugFix-Casting-Null-To-Type.sql
@@ -1,0 +1,52 @@
+CREATE OR REPLACE FUNCTION "user".check_session_token(p_session_token VARCHAR, p_browser_info TEXT)
+RETURNS TABLE (
+  message VARCHAR,
+  account_id INT,
+  username VARCHAR(64),
+  email VARCHAR,
+  created_at TIMESTAMP
+) AS $$
+DECLARE
+  user_id INT;
+BEGIN
+  -- Find the user_id associated with the session_token
+  SELECT acc_ses.account_id INTO user_id
+  FROM "user"."account_sessions" AS acc_ses
+  WHERE acc_ses.session_token = p_session_token;
+  
+  -- No matching session token...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'INVALID'::VARCHAR, NULL::INT, NULL::VARCHAR, NULL::VARCHAR, NULL::TIMESTAMP;
+  END IF;
+
+  -- Check for expiration
+  DELETE FROM "user"."account_sessions"
+  WHERE session_token = p_session_token
+  AND expiry_time < NOW();
+  
+  -- Token expired...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'EXPIRED'::VARCHAR, NULL::INT, NULL::VARCHAR, NULL::VARCHAR, NULL::TIMESTAMP;
+  END IF;
+
+  -- Check browser_info
+  SELECT COUNT(*) INTO user_id
+  FROM "user"."account_sessions" AS acc_ses
+  WHERE acc_ses.session_token = p_session_token
+  AND lower(acc_ses.browser_info) = lower(p_browser_info);
+  
+  -- Browser info doesn't match...
+  IF user_id = 0 THEN
+    -- Session token is likely compromised, so delete it.
+    DELETE FROM "user"."account_sessions"
+    WHERE session_token = p_session_token;
+
+    RETURN QUERY SELECT 'BROWSER'::VARCHAR, NULL::INT, NULL::VARCHAR, NULL::VARCHAR, NULL::TIMESTAMP;
+  END IF;
+
+  RETURN QUERY SELECT 'OK'::VARCHAR, u.id, u.username, u.email, u.created_at
+  FROM "user"."accounts" AS u
+  WHERE u.id = user_id;
+END;
+$$ LANGUAGE plpgsql;
+

--- a/postgreSQL-migrations/V2.8.8__Bugfix-Delete-Expire-Timedate-Consistency.sql
+++ b/postgreSQL-migrations/V2.8.8__Bugfix-Delete-Expire-Timedate-Consistency.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION "user".check_session_token(p_session_token VARCHAR, p_browser_info TEXT)
+RETURNS TABLE (
+  message VARCHAR,
+  account_id INT,
+  username VARCHAR(64),
+  email VARCHAR,
+  created_at TIMESTAMP
+) AS $$
+DECLARE
+  user_id INT;
+BEGIN
+  -- Find the user_id associated with the session_token
+  SELECT acc_ses.account_id INTO user_id
+  FROM "user"."account_sessions" AS acc_ses
+  WHERE acc_ses.session_token = p_session_token;
+  
+  -- No matching session token...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'INVALID'::VARCHAR, NULL::INT, NULL::VARCHAR, NULL::VARCHAR, NULL::TIMESTAMP;
+  END IF;
+
+  -- Check for expiration and delete if expired
+  DELETE FROM "user"."account_sessions"
+  WHERE session_token = p_session_token
+  AND expiry_time < (NOW() AT TIME ZONE 'GMT+8');
+  
+  -- Token expired...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'EXPIRED'::VARCHAR, NULL::INT, NULL::VARCHAR, NULL::VARCHAR, NULL::TIMESTAMP;
+  END IF;
+
+  -- Check browser_info
+  SELECT COUNT(*) INTO user_id
+  FROM "user"."account_sessions" AS acc_ses
+  WHERE acc_ses.session_token = p_session_token
+  AND lower(acc_ses.browser_info) = lower(p_browser_info);
+  
+  -- Browser info doesn't match...
+  IF user_id = 0 THEN
+    -- Session token is likely compromised, so delete it.
+    DELETE FROM "user"."account_sessions"
+    WHERE session_token = p_session_token;
+
+    RETURN QUERY SELECT 'BROWSER'::VARCHAR, NULL::INT, NULL::VARCHAR, NULL::VARCHAR, NULL::TIMESTAMP;
+  END IF;
+
+  -- Update last_used column
+  UPDATE "user"."account_sessions"
+  SET last_used = (NOW() AT TIME ZONE 'GMT+8')
+  WHERE session_token = p_session_token;
+
+  RETURN QUERY SELECT 'OK'::VARCHAR, u.id, u.username, u.email, u.created_at
+  FROM "user"."accounts" AS u
+  WHERE u.id = user_id;
+END;
+$$ LANGUAGE plpgsql;
+

--- a/postgreSQL-migrations/V2.8.9__Bugfix-Expired-Tokens.sql
+++ b/postgreSQL-migrations/V2.8.9__Bugfix-Expired-Tokens.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION "user".check_session_token(p_session_token VARCHAR, p_browser_info TEXT)
+RETURNS TABLE (
+  message VARCHAR,
+  account_id INT,
+  username VARCHAR(64),
+  email VARCHAR,
+  created_at TIMESTAMP
+) AS $$
+DECLARE
+  user_id INT;
+BEGIN
+  -- Find the user_id associated with the session_token
+  SELECT acc_ses.account_id INTO user_id
+  FROM "user"."account_sessions" AS acc_ses
+  WHERE acc_ses.session_token = p_session_token;
+  
+  -- No matching session token...
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'INVALID'::VARCHAR, NULL::INT, NULL::VARCHAR, NULL::VARCHAR, NULL::TIMESTAMP;
+  END IF;
+
+  -- Check for expiration and delete if expired
+  DELETE FROM "user"."account_sessions"
+  WHERE session_token = p_session_token
+  AND expiry_time < (NOW() AT TIME ZONE 'GMT+8');
+  
+  -- Token expired...
+  IF FOUND THEN
+    RETURN QUERY SELECT 'EXPIRED'::VARCHAR, NULL::INT, NULL::VARCHAR, NULL::VARCHAR, NULL::TIMESTAMP;
+  END IF;
+
+  -- Check browser_info
+  SELECT COUNT(*) INTO user_id
+  FROM "user"."account_sessions" AS acc_ses
+  WHERE acc_ses.session_token = p_session_token
+  AND lower(acc_ses.browser_info) = lower(p_browser_info);
+  
+  -- Browser info doesn't match...
+  IF user_id = 0 THEN
+    -- Session token is likely compromised, so delete it.
+    DELETE FROM "user"."account_sessions"
+    WHERE session_token = p_session_token;
+
+    RETURN QUERY SELECT 'BROWSER'::VARCHAR, NULL::INT, NULL::VARCHAR, NULL::VARCHAR, NULL::TIMESTAMP;
+  END IF;
+
+  -- Update last_used column
+  UPDATE "user"."account_sessions"
+  SET last_used = (NOW() AT TIME ZONE 'GMT+8')
+  WHERE session_token = p_session_token;
+
+  RETURN QUERY SELECT 'OK'::VARCHAR, u.id, u.username, u.email, u.created_at
+  FROM "user"."accounts" AS u
+  WHERE u.id = user_id;
+END;
+$$ LANGUAGE plpgsql;
+


### PR DESCRIPTION
Just fixes on namespace ambiguity, and bugfix on expired tokens, where non-expired tokens gets flagged as expired.