### PR TITLE
Database functions for session token deletion

### DIFF
--- a/postgreSQL-migrations/V3.3.0__Refactor-Delete-Session-Token.sql
+++ b/postgreSQL-migrations/V3.3.0__Refactor-Delete-Session-Token.sql
@@ -1,0 +1,48 @@
+DROP FUNCTION IF EXISTS "user".delete_session_token(VARCHAR);
+
+CREATE OR REPLACE FUNCTION "user".delete_session_token(
+    p_session_token VARCHAR,
+    p_browser_info TEXT,
+    target_session_token VARCHAR
+)
+RETURNS TABLE (MESSAGE TEXT) AS $$
+DECLARE
+    v_account_id INT;
+    v_target_account_id INT;
+BEGIN
+    SELECT account_id INTO v_account_id
+    FROM "user"."account_sessions"
+    WHERE session_token = p_session_token AND browser_info = p_browser_info;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT 'INVALID'::TEXT;
+        RETURN;
+    ELSIF v_account_id IS NULL THEN
+        -- Drop row if session token exists, but browser mismatch.
+        DELETE FROM "user"."account_sessions"
+        WHERE session_token = p_session_token;
+
+        RETURN QUERY SELECT 'BROWSER'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Check if target token exists, and if the account ID matches with the
+    -- requesting user's id.
+    SELECT account_id INTO v_target_account_id
+    FROM "user"."account_sessions"
+    WHERE session_token = target_session_token;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT 'NOT FOUND'::TEXT;
+        RETURN;
+    ELSIF v_target_account_id <> v_account_id THEN
+        RETURN QUERY SELECT 'ACCOUNT'::TEXT;
+        RETURN;
+    END IF;
+
+    DELETE FROM "user"."account_sessions"
+    WHERE session_token = target_session_token;
+
+    RETURN QUERY SELECT 'SUCCESS'::TEXT;
+END;
+$$ LANGUAGE plpgsql;

--- a/postgreSQL-migrations/V3.3.1__Bugfix-Get-Session-Token.sql
+++ b/postgreSQL-migrations/V3.3.1__Bugfix-Get-Session-Token.sql
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION "user"."get_session_tokens"(
+    p_session_token VARCHAR,
+    p_browser_info TEXT
+)
+RETURNS TABLE (
+    message TEXT,
+    session_token VARCHAR,
+    browser_info TEXT,
+    expiry_time TIMESTAMP,
+    created_at TIMESTAMP,
+    last_used TIMESTAMP
+)
+AS $$
+DECLARE
+    l_account_id INT;
+BEGIN
+    -- find account id...
+    SELECT account_id INTO l_account_id
+    FROM "user"."account_sessions" s
+    WHERE s.session_token = p_session_token;
+
+    -- find all session token matching the account id.
+    RETURN QUERY
+    SELECT
+        CASE
+			WHEN s.session_token IS NULL THEN 'INVALID'
+            WHEN s.expiry_time < NOW() AT TIME ZONE 'Asia/Singapore' THEN 'EXPIRED'
+            WHEN lower(s.browser_info) <> lower(p_browser_info) THEN 'BROWSER'
+            ELSE 'OK'
+        END AS message,
+        s.session_token,
+        s.browser_info,
+        s.expiry_time,
+        s.created_at,
+        s.last_used
+    FROM "user"."account_sessions" s
+    WHERE s.account_id = l_account_id;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
PR Title;

PostgreSQL functions to delete session tokens.

Additionally, bugfix on function for fetching session tokens. Where originally, the function would only ever return the row containing to the original session token.